### PR TITLE
FEAT: load bangs on start instead of lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This version includes several key improvements over the original project:
 
 1. Pre-fetches DuckDuckGo's bangs during build process
 2. Implements a hashmap for more efficient bang indexing (based on work from https://github.com/t3dotgg/unduck/pull/65)
-3. Optimizes performance by loading bangs on-demand during first search
-4. Provides complete opensearch & autocomplete integration
-5. Supports custom bang definitions (configurable in src/custom.ts)
-6. Deploys via Cloudflare Workers
+3. Provides complete opensearch & autocomplete integration
+4. Supports custom bang definitions (configurable in src/custom.ts)
+5. Deploys via Cloudflare Workers

--- a/scripts/download-bangs.ts
+++ b/scripts/download-bangs.ts
@@ -16,18 +16,11 @@ async function main() {
 	}
 	const template = `import { Bang } from "../types.ts";
 
+export const BANG_UPDATE_TIME = "${updateDate.toISOString()}";
 export const hashbang: Record<string, Bang> = ${JSON.stringify(hash)};`;
 	await fs.writeFile(path.join(__dirname, "..", "src", "ddbang.ts"), template, {
 		encoding: "utf-8",
 	});
-	const meta = `export const BANG_UPDATE_TIME = "${updateDate.toISOString()}";`;
-	await fs.writeFile(
-		path.join(__dirname, "..", "src", "ddbang-meta.ts"),
-		meta,
-		{
-			encoding: "utf-8",
-		},
-	);
 }
 
 main();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import clipboardCheck from "./assets/clipboard-check.svg";
 import clipboard from "./assets/clipboard.svg";
 import { hashbang as custombangs } from "./custom";
-import { BANG_UPDATE_TIME } from "./ddbang-meta";
+import { BANG_UPDATE_TIME, hashbang } from "./ddbang";
 
 function noSearchDefaultPageRender() {
 	if (import.meta.env.DEV) {
@@ -61,7 +61,6 @@ async function getBangredirectUrl() {
 	}
 
 	const LS_DEFAULT_BANG = localStorage.getItem("default-bang") ?? "g";
-	const { hashbang } = await import("./ddbang");
 	const defaultBang = hashbang[LS_DEFAULT_BANG];
 
 	const match = query.match(/!(\S+)/i);


### PR DESCRIPTION
## Summary

Load bangs directly instead of codesplit & load ondemand


# Stack

1. #1
1. #2 👈 